### PR TITLE
Add support for using bearer token and pulling single PR

### DIFF
--- a/lib/api/prs.js
+++ b/lib/api/prs.js
@@ -41,6 +41,19 @@ module.exports = function (client) {
       });
     },
 
+    getSpecific: function (projectKey, repo, id, options) {
+      if (!options) {
+        options = {};
+      }
+
+      var clientOptions = { args: { 'state': options.state || 'OPEN' } };
+      var path = 'projects/' + projectKey + '/repos/' + repo + '/pull-requests/' + id;
+
+      return client.get(path, clientOptions).then(function(response) {
+        return response;
+      })
+    },
+
     getCombined: function (projectKey, repo, options) {
 
       if (projectKey && repo) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -5,7 +5,7 @@ var request = require('request-promise');
 var _ = require('lodash');
 
 function validateAuth (auth) {
-  return !!(auth.username && auth.password);
+  return !!(auth.username && auth.password) || auth.bearer;
 }
 
 function validateOAuth (oauth) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -512,7 +513,8 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -616,6 +618,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -664,7 +667,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "mime-db": {
       "version": "1.35.0",
@@ -858,7 +862,8 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "request": {
       "version": "2.87.0",


### PR DESCRIPTION
Bitbucket Server 5.5 adds support for Personal Access Tokens, so we can start using that instead of username/passwords: https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html