### PR TITLE
Fix put to use PUT method instead of POST

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -104,7 +104,7 @@ Client.prototype.put = function (path, data) {
     json: true
   };
 
-  return request.post(params);
+  return request.put(params);
 };
 
 module.exports = Client;


### PR DESCRIPTION
client.put is attempting to use POST, but should be PUT. There's one call that uses this for enabling hooks, but the recent versions of the API require that to be PUT so it won't currently work.