### PR TITLE
Allow setting start on pull request calls

### DIFF
--- a/lib/api/prs.js
+++ b/lib/api/prs.js
@@ -26,7 +26,7 @@ module.exports = function (client) {
         options = {};
       }
 
-      var clientOptions = { args: { 'state': options.state || 'OPEN' } };
+      var clientOptions = { args: { 'state': options.state || 'OPEN', 'start': options.start || 0 } };
       var path = 'projects/' + projectKey + '/repos/' + repo + '/pull-requests';
 
       return client.getCollection(path, clientOptions).then(function (response) {


### PR DESCRIPTION
I'm in need to reaching beyond the first 1000 (or 100 depending on the server version) open pull requests. This pull request adds a `start` option too the pull request commands, which defaults to 0